### PR TITLE
Add retain history

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Rundown of the demo:
 2. **Simple Node.js Application**:
    - A very simple Node.js app which connects to Materialize using `SUBSCRIBE`. It runs in an infinite loop and listens for any changes to the specified view.
    - When changes are detected, the application reads these changes and forwards the relevant data to the Novu platform using Novu's API.
+   - The application also keeps track of the last progress timestamp for each subscription in a Materialize table. This can be changed to store the progress in a different database or service if needed.
 
 3. **Novu Platform**:
    - Novu receives the data from the Node.js application.
@@ -36,7 +37,53 @@ Before running this demo, ensure you have the following:
 
 To run this demo, follow these steps:
 
-1. Start by following the [Materialize Quickstart Guide](https://materialize.com/docs/get-started/quickstart/) to set up a load generator source in Materialize.
+1. Start by following the [Materialize Quickstart Guide](https://materialize.com/docs/get-started/quickstart/) to set up a load generator source in Materialize:
+
+```sql
+CREATE SOURCE IF NOT EXISTS auction_house_source
+FROM LOAD GENERATOR AUCTION (TICK INTERVAL '500ms')
+FOR ALL TABLES;
+
+CREATE VIEW on_time_bids AS
+    SELECT
+        bids.id       AS bid_id,
+        auctions.id   AS auction_id,
+        auctions.seller,
+        bids.buyer,
+        auctions.item,
+        bids.bid_time,
+        auctions.end_time,
+        bids.amount
+    FROM bids
+    JOIN auctions ON bids.auction_id = auctions.id
+    WHERE bids.bid_time < auctions.end_time;
+
+CREATE VIEW highest_bid_per_auction AS
+    SELECT grp.auction_id, bid_id, buyer, seller, item, amount, bid_time, end_time FROM
+        (SELECT DISTINCT auction_id FROM on_time_bids) grp,
+        LATERAL (
+            SELECT * FROM on_time_bids
+            WHERE auction_id = grp.auction_id
+            ORDER BY amount DESC LIMIT 1
+        );
+
+CREATE MATERIALIZED VIEW winning_bids AS
+    SELECT * FROM highest_bid_per_auction
+    WHERE end_time < mz_now();
+
+CREATE INDEX winning_bids_idx_amount ON winning_bids (amount);
+
+ALTER MATERIALIZED VIEW winning_bids SET (RETAIN HISTORY = FOR '1h');
+```
+
+1. Create a table in Materialize, where we will store the last progress timestamp for each subscription:
+
+    ```sql
+    CREATE TABLE subscribe_progress (
+        subscribe_name TEXT,
+        last_progress_mz_timestamp TEXT
+    );
+    ```
 
 1. **Clone the Repository:**
    ```bash
@@ -74,4 +121,14 @@ The application connects to a Materialize database and listens for updates to th
 
 The current implementation is a basic example to demonstrate the integration between Materialize and Novu.
 
-The `SUBSCRIBE` query in the application is currently using `SNAPSHOT = FALSE` so that it only receives new updates without the initial snapshot of the view. Depending on your use case, you might want to adjust this behavior and possibly use `RETAIN HISTORY` as well.
+- The `SUBSCRIBE` query in the application is currently using `SNAPSHOT = FALSE` so that it only receives new updates without the initial snapshot of the view.
+- Handle error where `AS OF` timestamp is past the retain history interval, currently this is hardcoded to 1 hour.
+- Make recording `last_progress_mz_timestamp` an async task that happens periodically.
+
+## Teardown
+
+Back in the SQL shell:
+
+```sql
+DROP SOURCE auction_house_source CASCADE;
+```

--- a/app.js
+++ b/app.js
@@ -2,13 +2,43 @@ import pkg from "pg";
 import { Novu } from "@novu/node";
 import "dotenv/config";
 
-// Initialize Novu with your API key.
 const novu = new Novu(process.env.NOVU_API_KEY);
 const { Client } = pkg;
 
+async function getLastProcessedTimestamp(client) {
+  const query = `
+      SELECT last_progress_mz_timestamp
+      FROM subscribe_progress
+      WHERE subscribe_name = 'notify_winners'
+      ORDER BY last_progress_mz_timestamp DESC
+      LIMIT 1`;
+  const result = await client.query(query);
+  return result.rows.length ? result.rows[0].last_progress_mz_timestamp : null;
+}
+
+async function updateLastProcessedTimestamp(client, subscribeName, timestamp) {
+  console.log("Updating last processed timestamp:", timestamp);
+  await client.query(
+    "DELETE FROM subscribe_progress WHERE subscribe_name = $1",
+    [subscribeName]
+  );
+  await client.query(
+    "INSERT INTO subscribe_progress (subscribe_name, last_progress_mz_timestamp) VALUES ($1, $2)",
+    [subscribeName, timestamp]
+  );
+}
+
 async function main() {
   console.log("Starting Materialize listener...");
-  const client = new Client({
+  const subscribeClient = new Client({
+    user: process.env.MATERIALIZE_USERNAME,
+    password: process.env.MATERIALIZE_PASSWORD,
+    host: process.env.MATERIALIZE_HOST,
+    port: process.env.MATERIALIZE_PORT,
+    database: process.env.MATERIALIZE_DATABASE,
+    ssl: process.env.MATERIALIZE_SSL === "true",
+  });
+  const updateClient = new Client({
     user: process.env.MATERIALIZE_USERNAME,
     password: process.env.MATERIALIZE_PASSWORD,
     host: process.env.MATERIALIZE_HOST,
@@ -17,21 +47,59 @@ async function main() {
     ssl: process.env.MATERIALIZE_SSL === "true",
   });
 
-  try {
-    console.log("Connecting to Materialize...");
-    await client.connect();
-    await client.query("BEGIN");
-    await client.query(
-      "DECLARE c CURSOR FOR SUBSCRIBE TO (SELECT * FROM winning_bids) WITH (SNAPSHOT = FALSE)"
-    );
+  await subscribeClient.connect();
+  await updateClient.connect();
+  console.log("Connected to Materialize...");
 
-    console.log("Listening for updates...");
+  const lastProcessedTimestamp = await getLastProcessedTimestamp(updateClient);
+  await subscribeClient.query("BEGIN");
+  const subscribeSQL = `DECLARE c CURSOR FOR SUBSCRIBE TO (SELECT * FROM winning_bids) WITH (SNAPSHOT = FALSE) ${
+    lastProcessedTimestamp ? `AS OF ${lastProcessedTimestamp}` : ""
+  }`;
+  console.log("Subscribing with:", subscribeSQL);
+  await subscribeClient.query(subscribeSQL);
+
+  console.log("Listening for updates...");
+  try {
+    let buffer = [];
+    let lastTimestamp = null;
     while (true) {
-      const res = await client.query("FETCH ALL c");
+      const res = await subscribeClient.query("FETCH ALL c");
       if (res.rows.length > 0) {
         console.log("Received rows:", res.rows);
-        res.rows.forEach(row => handleMaterializeUpdate(row));
+        for (const row of res.rows) {
+          if (lastTimestamp === null || lastTimestamp === row.mz_timestamp) {
+            buffer.push(row);
+            lastTimestamp = row.mz_timestamp;
+          } else {
+            // Process the buffer
+            for (const bufferedRow of buffer) {
+              handleMaterializeUpdate(bufferedRow);
+            }
+            await updateLastProcessedTimestamp(
+              updateClient,
+              "notify_winners",
+              lastTimestamp
+            );
+            // Clear the buffer and add the current row to it
+            buffer = [row];
+            lastTimestamp = row.mz_timestamp;
+          }
+        }
       } else {
+        if (buffer.length > 0) {
+          // Process remaining items in the buffer
+          for (const bufferedRow of buffer) {
+            handleMaterializeUpdate(bufferedRow);
+          }
+          await updateLastProcessedTimestamp(
+            updateClient,
+            "notify_winners",
+            lastTimestamp
+          );
+          buffer = [];
+          lastTimestamp = null;
+        }
         console.log("No new data.");
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
@@ -39,12 +107,12 @@ async function main() {
   } catch (error) {
     console.error("Error:", error);
   } finally {
-    await client.end();
+    await subscribeClient.end();
+    await updateClient.end();
   }
 }
 
 function handleMaterializeUpdate(data) {
-  // Example trigger logic for Novu
   console.log("Triggering notification for:", data);
   novu
     .trigger("materialize-poc-notification-workflow", {


### PR DESCRIPTION
Had some time today to extend this slightly and use `RETAIN HISTORY`. This is more or less a copy of the implementation that @chaas did here:

> https://github.com/chuck-alt-delete/mz-auction-house/compare/main...chaas:mz-auction-house:retain-history-testing

This PR has more or less the same concerns as listed in the above project. Currently, this uses a local Materialize table to store the progress.

One thing that I was thinking while making the changes was maybe turning this into a little CLI tool that would accept different parameters, eg:

```sh
novu-mz-subscribe --query 'SELECT * FROM winning_bids' \
                                  --snapshot false \
                                  --progress-table last_progress_mz_timestamp \
                                  --progress-timestamp SOME_VALUE_TO_OVERWRITE_THE_PROGRESS_TABLE
                                  --some-more-params
```